### PR TITLE
Tweak the Makefile a bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
 #	    ULPM is a simple Unified Linux Package Manager with minimum requirements and works on all linux distributions.
 #		Copyright (C) 2016  Jake Backer <jbacker42@gmail.com>
 
+CXX?=g++
+CXXFLAGS?=-Wall -Wextra -O2 -pipe
+
 all: ulpm.cpp
-	g++ ulpm.cpp -o out/ulpm
+	mkdir -p out
+	$(CXX) ulpm.cpp $(CXXFLAGS) -o out/ulpm
 	chmod +x out/ulpm
-	sudo install out/ulpm /usr/bin
 
-clean: 
-	$(RM) out/ulpm
+install: all
+	install out/ulpm /usr/bin
 
-setup:
-	mkdir out
+uninstall:
+	rm /usr/bin/ulpm
+
+clean:
+	rm out/ulpm


### PR DESCRIPTION
* Add an "uninstall" goal
* Remove sudo. Some systems may not have or require it. Using sudo is the users job.
  * Plus, now we have two-thirds of the "./configure; make; sudo make install" trifecta
* Make compiler and compiler flags something that can be overwritten by the user's preferences
* Removed setup goal as "mkdir -p" will create the directory if it doesn't exist